### PR TITLE
Debian以外の環境でビルドできない不具合の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Custom Linux ISO build tool
 - root権限 または sudo  
 - 以下パッケージ（ホスト側）  
   ```
-  mmdebstrap rsync squashfs-tools grub-pc-bin grub-efi-amd64-bin grub-efi-amd64-signed shim-signed xorriso dosfstools mtools python3-venv python3-pip git
+  mmdebstrap rsync squashfs-tools grub-pc-bin grub-efi-amd64-bin grub-efi-amd64-signed shim-signed xorriso dosfstools mtools python3-venv python3-pip git debian-archive-keyring
   ```
 
 ---

--- a/lib/builder.py
+++ b/lib/builder.py
@@ -530,6 +530,9 @@ def _prepare_chroot(codename: str):
         # calamaresインストールでエラーになるため"important"を指定する
         "--variant=important",
 
+        # non-debian環境でのGPG鍵エラー対策
+        "--keyring=/usr/share/keyrings/debian-archive-keyring.gpg",
+
         # ── 並列ダウンロード・リトライ設定 ──
         "--aptopt=Acquire::Queue-Mode \"host\";",
         "--aptopt=Acquire::Retries \"3\";",

--- a/lib/builder.py
+++ b/lib/builder.py
@@ -495,7 +495,8 @@ def _prepare_chroot(codename: str):
             ]
 
     # ── 2) mmdebstrap に渡す必須パッケージ群 ──
-    base_pkgs = ["bash", "coreutils"]
+    # non-debian 環境でのビルド時、GPG鍵不足で失敗する問題の対策
+    base_pkgs = ["bash", "coreutils", "debian-archive-keyring"]
     include_pkgs = sorted(set(base_pkgs + pkg_list))
 
     # Secure Boot対応：署名済みカーネルの確実なインストール


### PR DESCRIPTION
# GPG 署名不具合修正について

## 修正の概要

Debian 以外の Linux 環境（Ubuntu など）でビルドを実行した際に、mmdebstrap が Debian リポジトリの GPG 署名を検
証できずに失敗する問題を修正しました。

## 修正内容

mmdebstrap のコマンドラインに--keyring オプションを追加し、ホスト OS にインストールされている Debian の GPG
キーリングファイル（/usr/share/keyrings/debian-archive-keyring.gpg）を明示的に指定するように変更しま
した。

これにより、mmdebstrap はリポジトリのインデックスを読み込む段階で正しい GPG キーを参照できるようになり
、署名検証エラーが解消されます。

## 前提条件

この修正を有効にするには、ビル d を実行するホスト環境に debian-archive-keyring パッケージがインストール
されている必要があります。未導入の場合は、以下のコマンドでインストールしてください。

1 sudo apt install debian-archive-keyring

テスト環境

- OS: Ubuntu 24.04
- 対応内容: 上記前提条件を満たした上でビルドが正常に完了することを確認。
