### PR TITLE
Fix oYo apt keyring path in post-install hook

### DIFF
--- a/config/40_brand/oYo/hooks/post-install.d/20-apt-install-oYoAplication.sh
+++ b/config/40_brand/oYo/hooks/post-install.d/20-apt-install-oYoAplication.sh
@@ -11,9 +11,10 @@ set -e
 dpkg -i /usr/share/openyellowos/oyo-archive-keyring_1.0_all.deb
 
 # 2) リポ登録（amd64 限定）
-install -d -m 0755 /etc/apt/keyrings
+#    keyring deb は /usr/share/keyrings/oyo-archive.gpg を配置するため
+#    signed-by も同一パスを参照する
 tee /etc/apt/sources.list.d/oyo.list >/dev/null <<'EOF'
-deb [arch=amd64 signed-by=/etc/apt/keyrings/oyo-archive.gpg] https://deb.openyellowos.com kerria main
+deb [arch=amd64 signed-by=/usr/share/keyrings/oyo-archive.gpg] https://deb.openyellowos.com kerria main
 EOF
 
 # 3) 更新

--- a/config/40_brand/oYo/overlay/etc/apt/sources.list.d/oyo.list
+++ b/config/40_brand/oYo/overlay/etc/apt/sources.list.d/oyo.list
@@ -1,1 +1,1 @@
-deb [arch=amd64 signed-by=/etc/apt/keyrings/oyo-archive.gpg] https://deb.openyellowos.com kerria main
+deb [arch=amd64 signed-by=/usr/share/keyrings/oyo-archive.gpg] https://deb.openyellowos.com kerria main


### PR DESCRIPTION
### Motivation
- The chroot `apt update` failed with exit code 100 because the `signed-by` path in the post-install hook pointed to `/etc/apt/keyrings/oyo-archive.gpg` while the installed keyring is placed at `/usr/share/keyrings/oyo-archive.gpg` inside the .deb.
- Aligning the `signed-by` path with the actual key location prevents `apt update` from failing during the post-install stage in the build workflow.

### Description
- Updated `config/40_brand/oYo/hooks/post-install.d/20-apt-install-oYoAplication.sh` to write the repo entry with `signed-by=/usr/share/keyrings/oyo-archive.gpg` instead of `/etc/apt/keyrings/oyo-archive.gpg`.
- Updated overlay file `config/40_brand/oYo/overlay/etc/apt/sources.list.d/oyo.list` to use the same `signed-by=/usr/share/keyrings/oyo-archive.gpg` path for consistency.
- Added brief comments explaining the key location choice in the hook script.

### Testing
- Ran `bash -n config/40_brand/oYo/hooks/post-install.d/20-apt-install-oYoAplication.sh` and the syntax check passed.
- Verified the `.deb` contains `usr/share/keyrings/oyo-archive.gpg` with `dpkg-deb -c config/40_brand/oYo/overlay/usr/share/openyellowos/oyo-archive-keyring_1.0_all.deb | rg 'oyo-archive.gpg'` which returned the expected path.
- Confirmed the modified `oyo.list` file now contains `signed-by=/usr/share/keyrings/oyo-archive.gpg` via a file read, and no script syntax errors were detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6b1607df8832692b00e9c75c88ffb)